### PR TITLE
fix(warnings): add statement after a label

### DIFF
--- a/ocre-sdk/ocre_api.c
+++ b/ocre-sdk/ocre_api.c
@@ -171,6 +171,7 @@ void ocre_process_events(void)
             printf("Unknown event: type=%d, id=%d, port=%d, state=%d\n",
                    event_data.type, event_data.id, event_data.port, event_data.state);
 #endif
+            break;
         }
         event_count++;
     }


### PR DESCRIPTION
Removes the following warning
```bash
ocre-sdk/ocre-sdk/ocre_api.c:174:9: warning: label at end of compound statement is a C23 extension [-Wc23-extensions]
  174 |         }
      |         ^
1 warning generated.
```